### PR TITLE
Feature default command

### DIFF
--- a/dist/devilbox-cli.sh
+++ b/dist/devilbox-cli.sh
@@ -608,7 +608,8 @@ get_devilbox_path() {
 main () {
     safe_cd "$(get_devilbox_path)" "Devilbox not found, please make sure it is installed in your home directory or use DEVILBOX_PATH in your profile."
     if [[ $# -eq 0 ]] ; then
-        run_command
+        version_command
+        help_command
     else
         case $1 in
             c|config) shift; config_command "$@";;

--- a/src/main.sh
+++ b/src/main.sh
@@ -18,7 +18,8 @@ get_devilbox_path() {
 main () {
     safe_cd "$(get_devilbox_path)" "Devilbox not found, please make sure it is installed in your home directory or use DEVILBOX_PATH in your profile."
     if [[ $# -eq 0 ]] ; then
-        run_command
+        version_command
+        help_command
     else
         case $1 in
             c|config) shift; config_command "$@";;


### PR DESCRIPTION
Hello Louis-Gabriel,

I've another PR as suggestion, because I think we should not run containers when we run only the `devilbox-cli` command.
Perharps as I did it in this PR, only show the version and help screen. That will allow to make possible config change before running containers.
Tell me what you think about it !

BTW, I've another PR that I would like to suggest. It will add a new `compose` command to help to handle additional docker services.
Tell me also, if you think it will be useful for community and your project.

Thanks in advance
Laurent
